### PR TITLE
Dodato da se moze pristupati auth() sa 404error strane

### DIFF
--- a/implementacija/app/Http/Kernel.php
+++ b/implementacija/app/Http/Kernel.php
@@ -17,6 +17,8 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrustProxies::class,
         \Fruitcake\Cors\HandleCors::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,


### PR DESCRIPTION
-  dopunjen middleware niz kako bi se na 404 strani moglo pristupati auth() funkcionalnostima (radi prikaza odgovarajucih ikonica u navbaru)